### PR TITLE
Change end date for schedule in speakers

### DIFF
--- a/components/website/speakers/Schedule/index.jsx
+++ b/components/website/speakers/Schedule/index.jsx
@@ -62,7 +62,7 @@ function addDate(date, days) {
 
 export default function Schedule(props) {
   const min_date = "2022/2/15";
-  const max_date = "2022/2/20";
+  const max_date = "2022/2/18";
 
   //calculate default date
   const _today = new Date();


### PR DESCRIPTION
The last date of the schedule in the speakers page should be the 18th and not the 20th.