### PR TITLE
Fixed typo on "You din't win anything".

### DIFF
--- a/pages/attendee/wheel.js
+++ b/pages/attendee/wheel.js
@@ -103,7 +103,7 @@ function WheelPage() {
         } else if (response.prize.name == "Nada") {
           updateWheelMessage(
             <WheelMessage
-              title="You din't win anything!"
+              title="You didn't win anything!"
               description="Better luck next time."
               onExit={(_) => updateWheelMessage(null)}
             />


### PR DESCRIPTION
Fixed typo on "You din't win anything" to "You didn't win anything" on wheel.