### PR TITLE
Add frame options to netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,10 @@
 
 [context.deploy-preview.environment]
   NEXT_PUBLIC_API_URL = "https://sei23-production.herokuapp.com"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+


### PR DESCRIPTION
This prevents the website from being displayed in `<iframe>` or `<embed>`, making us not vulnerable to clickjacking.