### PR TITLE
feat: add password visibility button to authentication pages

### DIFF
--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -2,7 +2,6 @@ import { forwardRef, InputHTMLAttributes } from "react";
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   text: string;
-  autocomplete?: string;
   fgColor: string;
   bgColor: string;
   enabled?: boolean;
@@ -38,7 +37,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
     name,
     type,
     value,
-    autocomplete,
+    autoComplete,
     fgColor,
     bgColor,
     onChange,
@@ -60,7 +59,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
           id={id}
           name={name}
           type={type}
-          autoComplete={autocomplete}
+          autoComplete={autoComplete}
           value={value}
           required
           className="w-full bg-transparent outline-none"

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -1,30 +1,26 @@
-import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
+import { forwardRef, InputHTMLAttributes } from "react";
 
-interface Props extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputBaseProps
+  extends Pick<InputHTMLAttributes<HTMLDivElement>, "id" | "children"> {
   text: string;
   fgColor: string;
   bgColor: string;
   enabled?: boolean;
-  right?: ReactNode;
 }
 
-export default forwardRef<HTMLInputElement, Props>(function Input(
-  {
-    text,
-    id,
-    name,
-    type,
-    value,
-    autoComplete,
-    fgColor,
-    bgColor,
-    onChange,
-    enabled,
-    right,
-    ...rest
-  },
-  ref
-) {
+export interface InputDefaultProps
+  extends InputBaseProps,
+    InputHTMLAttributes<HTMLInputElement> {}
+
+// A wrapper to the <input> to standardize styles for the container
+export function InputBase({
+  text,
+  id,
+  fgColor,
+  bgColor,
+  enabled,
+  children,
+}: InputBaseProps) {
   let textColor = `text-${fgColor}`;
   let backColor = `bg-${bgColor}`;
 
@@ -47,21 +43,49 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
       <div
         className={`text-iregular mt-2 flex items-center ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`}
       >
-        <input
-          id={id}
-          name={name}
-          type={type}
-          autoComplete={autoComplete}
-          value={value}
-          required
-          className="w-full bg-transparent outline-none"
-          onChange={onChange}
-          disabled={enabled == false}
-          ref={ref}
-          {...rest}
-        />
-        {right}
+        {children}
       </div>
     </div>
+  );
+}
+
+export default forwardRef<HTMLInputElement, InputDefaultProps>(function Input(
+  {
+    text,
+    id,
+    name,
+    type,
+    value,
+    autoComplete,
+    fgColor,
+    bgColor,
+    onChange,
+    enabled,
+    ...rest
+  },
+  ref
+) {
+  return (
+    <InputBase
+      text={text}
+      id={id}
+      fgColor={fgColor}
+      bgColor={bgColor}
+      enabled={enabled}
+    >
+      <input
+        id={id}
+        name={name}
+        type={type}
+        autoComplete={autoComplete}
+        value={value}
+        required
+        className="w-full bg-transparent outline-none"
+        onChange={onChange}
+        disabled={enabled == false}
+        ref={ref}
+        {...rest}
+      />
+    </InputBase>
   );
 });

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
+import { forwardRef, InputHTMLAttributes } from "react";
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   text: string;
@@ -6,8 +6,30 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
   fgColor: string;
   bgColor: string;
   enabled?: boolean;
-  right?: ReactNode;
 }
+
+/*
+ * This function exists to prevent other Input similar components (like PasswordInput) to have different styles
+ * if somebody forget to edit the styles across all components
+ */
+export const inputStyle = (
+  fgColor: string,
+  bgColor: string,
+  enabled: boolean
+) => {
+  let textColor = `text-${fgColor}`;
+  let backColor = `bg-${bgColor}`;
+
+  if (enabled === false) {
+    textColor = "text-gray-500";
+    backColor = "bg-gray-100";
+  } else if (enabled === true) {
+    textColor = `bg-${fgColor}`;
+    backColor = `bg-${bgColor}`;
+  }
+
+  return `text-iregular mt-2 flex items-center ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`;
+};
 
 export default forwardRef<HTMLInputElement, Props>(function Input(
   {
@@ -21,22 +43,10 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
     bgColor,
     onChange,
     enabled,
-    right,
     ...rest
   },
   ref
 ) {
-  let textColor = `text-${fgColor}`;
-  let backColor = `bg-${bgColor}`;
-
-  if (enabled === false) {
-    textColor = "text-gray-500";
-    backColor = "bg-gray-100";
-  } else if (enabled === true) {
-    textColor = `bg-${fgColor}`;
-    backColor = `bg-${bgColor}`;
-  }
-
   return (
     <div>
       <label
@@ -45,9 +55,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
       >
         {text}
       </label>
-      <div
-        className={`text-iregular mt-2 flex items-center ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`}
-      >
+      <div className={inputStyle(fgColor, bgColor, enabled)}>
         <input
           id={id}
           name={name}
@@ -61,7 +69,6 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
           ref={ref}
           {...rest}
         />
-        {right}
       </div>
     </div>
   );

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, InputHTMLAttributes } from "react";
+import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   text: string;
@@ -6,6 +6,7 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
   fgColor: string;
   bgColor: string;
   enabled?: boolean;
+  right?: ReactNode;
 }
 
 export default forwardRef<HTMLInputElement, Props>(function Input(
@@ -20,6 +21,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
     bgColor,
     onChange,
     enabled,
+    right,
     ...rest
   },
   ref
@@ -43,7 +45,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
       >
         {text}
       </label>
-      <div className="mt-2">
+      <div className={`flex mt-2 text-iregular ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`}>
         <input
           id={id}
           name={name}
@@ -51,7 +53,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
           autoComplete={autocomplete}
           value={value}
           required
-          className={`text-iregular ${textColor} ${backColor} block w-full appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm focus:outline-none sm:text-sm`}
+          className="bg-transparent w-full outline-none"
           onChange={onChange}
           disabled={enabled == false}
           ref={ref}

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -1,34 +1,12 @@
-import { forwardRef, InputHTMLAttributes } from "react";
+import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   text: string;
   fgColor: string;
   bgColor: string;
   enabled?: boolean;
+  right?: ReactNode;
 }
-
-/*
- * This function exists to prevent other Input similar components (like PasswordInput) to have different styles
- * if somebody forget to edit the styles across all components
- */
-export const inputStyle = (
-  fgColor: string,
-  bgColor: string,
-  enabled: boolean
-) => {
-  let textColor = `text-${fgColor}`;
-  let backColor = `bg-${bgColor}`;
-
-  if (enabled === false) {
-    textColor = "text-gray-500";
-    backColor = "bg-gray-100";
-  } else if (enabled === true) {
-    textColor = `bg-${fgColor}`;
-    backColor = `bg-${bgColor}`;
-  }
-
-  return `text-iregular mt-2 flex items-center ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`;
-};
 
 export default forwardRef<HTMLInputElement, Props>(function Input(
   {
@@ -42,10 +20,22 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
     bgColor,
     onChange,
     enabled,
+    right,
     ...rest
   },
   ref
 ) {
+  let textColor = `text-${fgColor}`;
+  let backColor = `bg-${bgColor}`;
+
+  if (enabled === false) {
+    textColor = "text-gray-500";
+    backColor = "bg-gray-100";
+  } else if (enabled === true) {
+    textColor = `bg-${fgColor}`;
+    backColor = `bg-${bgColor}`;
+  }
+
   return (
     <div>
       <label
@@ -54,7 +44,9 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
       >
         {text}
       </label>
-      <div className={inputStyle(fgColor, bgColor, enabled)}>
+      <div
+        className={`text-iregular mt-2 flex items-center ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`}
+      >
         <input
           id={id}
           name={name}
@@ -68,6 +60,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
           ref={ref}
           {...rest}
         />
+        {right}
       </div>
     </div>
   );

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -45,7 +45,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
       >
         {text}
       </label>
-      <div className={`flex mt-2 text-iregular ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`}>
+      <div className={`flex items-center mt-2 text-iregular ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`}>
         <input
           id={id}
           name={name}
@@ -59,6 +59,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
           ref={ref}
           {...rest}
         />
+        {right}
       </div>
     </div>
   );

--- a/components/Input/index.tsx
+++ b/components/Input/index.tsx
@@ -45,7 +45,9 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
       >
         {text}
       </label>
-      <div className={`flex items-center mt-2 text-iregular ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`}>
+      <div
+        className={`text-iregular mt-2 flex items-center ${textColor} ${backColor} appearance-none rounded-full border border-gray-300 px-3 py-2 pl-6 placeholder-gray-400 shadow-sm sm:text-sm`}
+      >
         <input
           id={id}
           name={name}
@@ -53,7 +55,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
           autoComplete={autocomplete}
           value={value}
           required
-          className="bg-transparent w-full outline-none"
+          className="w-full bg-transparent outline-none"
           onChange={onChange}
           disabled={enabled == false}
           ref={ref}

--- a/components/PasswordInput/index.tsx
+++ b/components/PasswordInput/index.tsx
@@ -43,17 +43,17 @@ export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
       </label>
       <div className={inputStyle(fgColor, bgColor, enabled)}>
         <input
-          {...rest}
-          type={isPasswordVisible ? "text" : "password"}
-          autoComplete={autoComplete}
           id={id}
           name={name}
+          type={isPasswordVisible ? "text" : "password"}
+          autoComplete={autoComplete}
           value={value}
           required
           className="w-full bg-transparent outline-none"
           onChange={onChange}
           disabled={enabled == false}
           ref={ref}
+          {...rest}
         />
         <FontAwesomeIcon
           className="mx-2 cursor-pointer"

--- a/components/PasswordInput/index.tsx
+++ b/components/PasswordInput/index.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, InputHTMLAttributes, useState } from "react";
 
-import Input from "@components/Input";
+import { inputStyle } from "@components/Input";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
@@ -17,8 +17,13 @@ export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
     text = "PASSWORD",
     type = "password",
     autoComplete = "current-password",
+    id,
+    name,
+    value,
     fgColor,
     bgColor,
+    onChange,
+    enabled,
     ...rest
   },
   ref
@@ -28,23 +33,34 @@ export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
   const togglePasswordVisibility = () => {
     setIsPasswordVisible(!isPasswordVisible);
   };
-
   return (
-    <Input
-      {...rest}
-      text={text}
-      type={isPasswordVisible ? "text" : "password"}
-      fgColor="white"
-      bgColor="primary"
-      autoComplete={autoComplete}
-      right={
+    <div>
+      <label
+        htmlFor={id}
+        className={`pl-6 font-iregular text-${fgColor} mt-5 block text-sm`}
+      >
+        {text}
+      </label>
+      <div className={inputStyle(fgColor, bgColor, enabled)}>
+        <input
+          {...rest}
+          type={isPasswordVisible ? "text" : "password"}
+          autoComplete={autoComplete}
+          id={id}
+          name={name}
+          value={value}
+          required
+          className="w-full bg-transparent outline-none"
+          onChange={onChange}
+          disabled={enabled == false}
+          ref={ref}
+        />
         <FontAwesomeIcon
           className="mx-2 cursor-pointer"
           onClick={togglePasswordVisibility}
           icon={isPasswordVisible ? faEyeSlash : faEye}
         />
-      }
-      ref={ref}
-    />
+      </div>
+    </div>
   );
 });

--- a/components/PasswordInput/index.tsx
+++ b/components/PasswordInput/index.tsx
@@ -46,7 +46,7 @@ export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
       autoComplete="current-password"
       right={
         <FontAwesomeIcon
-          className="mx-2"
+          className="mx-2 cursor-pointer"
           onClick={togglePasswordVisibility}
           icon={isPasswordVisible ? faEyeSlash : faEye}
         />

--- a/components/PasswordInput/index.tsx
+++ b/components/PasswordInput/index.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, InputHTMLAttributes, useState } from "react";
 
-import { inputStyle } from "@components/Input";
+import Input from "@components/Input";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
@@ -17,13 +17,8 @@ export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
     text = "PASSWORD",
     type = "password",
     autoComplete = "current-password",
-    id,
-    name,
-    value,
     fgColor,
     bgColor,
-    onChange,
-    enabled,
     ...rest
   },
   ref
@@ -33,34 +28,23 @@ export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
   const togglePasswordVisibility = () => {
     setIsPasswordVisible(!isPasswordVisible);
   };
+
   return (
-    <div>
-      <label
-        htmlFor={id}
-        className={`pl-6 font-iregular text-${fgColor} mt-5 block text-sm`}
-      >
-        {text}
-      </label>
-      <div className={inputStyle(fgColor, bgColor, enabled)}>
-        <input
-          id={id}
-          name={name}
-          type={isPasswordVisible ? "text" : "password"}
-          autoComplete={autoComplete}
-          value={value}
-          required
-          className="w-full bg-transparent outline-none"
-          onChange={onChange}
-          disabled={enabled == false}
-          ref={ref}
-          {...rest}
-        />
+    <Input
+      {...rest}
+      text={text}
+      type={isPasswordVisible ? "text" : "password"}
+      fgColor="white"
+      bgColor="primary"
+      autoComplete={autoComplete}
+      right={
         <FontAwesomeIcon
           className="mx-2 cursor-pointer"
           onClick={togglePasswordVisibility}
           icon={isPasswordVisible ? faEyeSlash : faEye}
         />
-      </div>
-    </div>
+      }
+      ref={ref}
+    />
   );
 });

--- a/components/PasswordInput/index.tsx
+++ b/components/PasswordInput/index.tsx
@@ -1,0 +1,57 @@
+import { forwardRef, InputHTMLAttributes, useState } from "react";
+
+import Input from "@components/Input";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  text?: string;
+  autocomplete?: string;
+  fgColor: string;
+  bgColor: string;
+  enabled?: boolean;
+}
+
+export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
+  {
+    text = "PASSWORD",
+    id = "password",
+    name = "password",
+    type = "password",
+    autocomplete = "current-password",
+    fgColor,
+    bgColor,
+    ...rest
+  },
+  ref
+) {
+
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const togglePasswordVisibility = () => {
+    setIsPasswordVisible(!isPasswordVisible);
+  };
+
+  return (
+    <Input
+      {...rest}
+      text={text}
+      id={id}
+      name={name}
+      type={isPasswordVisible ? "text" : "password"}
+      fgColor="white"
+      bgColor="primary"
+      autoComplete="current-password"
+      right={
+        <FontAwesomeIcon
+          className="mx-2"
+          onClick={togglePasswordVisibility}
+          icon={isPasswordVisible ? faEyeSlash : faEye}
+        />
+      }
+      ref={ref}
+    />
+  );
+});

--- a/components/PasswordInput/index.tsx
+++ b/components/PasswordInput/index.tsx
@@ -1,50 +1,45 @@
-import { forwardRef, InputHTMLAttributes, useState } from "react";
+import { forwardRef, useState } from "react";
 
-import Input from "@components/Input";
+import { InputBase, InputDefaultProps } from "@components/Input";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
-interface Props extends InputHTMLAttributes<HTMLInputElement> {
-  text?: string;
-  fgColor: string;
-  bgColor: string;
-  enabled?: boolean;
-}
+export default forwardRef<HTMLInputElement, InputDefaultProps>(
+  function PasswordInput(
+    { text, id, name, type, fgColor, bgColor, enabled, ...rest },
+    ref
+  ) {
+    const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
-export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
-  {
-    text = "PASSWORD",
-    type = "password",
-    autoComplete = "current-password",
-    fgColor,
-    bgColor,
-    ...rest
-  },
-  ref
-) {
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+    const togglePasswordVisibility = () => {
+      setIsPasswordVisible(!isPasswordVisible);
+    };
 
-  const togglePasswordVisibility = () => {
-    setIsPasswordVisible(!isPasswordVisible);
-  };
-
-  return (
-    <Input
-      {...rest}
-      text={text}
-      type={isPasswordVisible ? "text" : "password"}
-      fgColor="white"
-      bgColor="primary"
-      autoComplete={autoComplete}
-      right={
+    return (
+      <InputBase
+        text={text}
+        id={id}
+        fgColor={fgColor}
+        bgColor={bgColor}
+        enabled={enabled}
+      >
+        <input
+          id={id}
+          name={name}
+          type={isPasswordVisible ? "text" : "password"}
+          required
+          className="w-full bg-transparent outline-none"
+          disabled={enabled == false}
+          ref={ref}
+          {...rest}
+        />
         <FontAwesomeIcon
           className="mx-2 cursor-pointer"
           onClick={togglePasswordVisibility}
           icon={isPasswordVisible ? faEyeSlash : faEye}
         />
-      }
-      ref={ref}
-    />
-  );
-});
+      </InputBase>
+    );
+  }
+);

--- a/components/PasswordInput/index.tsx
+++ b/components/PasswordInput/index.tsx
@@ -7,7 +7,6 @@ import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   text?: string;
-  autocomplete?: string;
   fgColor: string;
   bgColor: string;
   enabled?: boolean;
@@ -16,10 +15,8 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
 export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
   {
     text = "PASSWORD",
-    id = "password",
-    name = "password",
     type = "password",
-    autocomplete = "current-password",
+    autoComplete = "current-password",
     fgColor,
     bgColor,
     ...rest
@@ -36,12 +33,10 @@ export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
     <Input
       {...rest}
       text={text}
-      id={id}
-      name={name}
       type={isPasswordVisible ? "text" : "password"}
       fgColor="white"
       bgColor="primary"
-      autoComplete="current-password"
+      autoComplete={autoComplete}
       right={
         <FontAwesomeIcon
           className="mx-2 cursor-pointer"

--- a/components/PasswordInput/index.tsx
+++ b/components/PasswordInput/index.tsx
@@ -5,7 +5,6 @@ import Input from "@components/Input";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
-
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   text?: string;
   autocomplete?: string;
@@ -27,7 +26,6 @@ export default forwardRef<HTMLInputElement, Props>(function PasswordInput(
   },
   ref
 ) {
-
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   const togglePasswordVisibility = () => {

--- a/layout/Login/components/LoginForm/index.tsx
+++ b/layout/Login/components/LoginForm/index.tsx
@@ -36,14 +36,14 @@ export default function LoginForm() {
           autoComplete="email"
           ref={emailRef}
         />
-        <div>
-          <PasswordInput
-            text="YOUR PASSWORD"
-            fgColor="white"
-            bgColor="primary"
-            ref={passwordRef}
-          />
-        </div>
+        <PasswordInput
+          text="YOUR PASSWORD"
+          id="password"
+          name="password"
+          fgColor="white"
+          bgColor="primary"
+          ref={passwordRef}
+        />
         <Text
           padding="6"
           text="Forgot your password?"

--- a/layout/Login/components/LoginForm/index.tsx
+++ b/layout/Login/components/LoginForm/index.tsx
@@ -23,7 +23,6 @@ export default function LoginForm() {
     login({ email, password });
   };
 
-
   return (
     <div className="mt-8">
       <Form onSubmit={onFinish}>

--- a/layout/Login/components/LoginForm/index.tsx
+++ b/layout/Login/components/LoginForm/index.tsx
@@ -15,7 +15,7 @@ export default function LoginForm() {
   const { errors, login, isLoading } = useAuth();
   const emailRef = useRef(null);
   const passwordRef = useRef(null);
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   const onFinish = (event) => {
     event.preventDefault();
@@ -27,8 +27,8 @@ export default function LoginForm() {
   };
 
   const togglePasswordVisibility = () => {
-    setIsPasswordVisible(!isPasswordVisible)
-  }
+    setIsPasswordVisible(!isPasswordVisible);
+  };
 
   return (
     <div className="mt-8">
@@ -48,7 +48,7 @@ export default function LoginForm() {
             text="YOUR PASSWORD"
             id="password"
             name="password"
-            type={isPasswordVisible ? "text" : "password"} 
+            type={isPasswordVisible ? "text" : "password"}
             fgColor="white"
             bgColor="primary"
             autoComplete="current-password"

--- a/layout/Login/components/LoginForm/index.tsx
+++ b/layout/Login/components/LoginForm/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 import { useAuth } from "@context/Auth";
 
@@ -8,10 +8,14 @@ import Text from "@layout/moonstone/authentication/Text";
 import Form from "@components/Form";
 import Input from "@components/Input";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+
 export default function LoginForm() {
   const { errors, login, isLoading } = useAuth();
   const emailRef = useRef(null);
   const passwordRef = useRef(null);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
   const onFinish = (event) => {
     event.preventDefault();
@@ -21,6 +25,10 @@ export default function LoginForm() {
 
     login({ email, password });
   };
+
+  const togglePasswordVisibility = () => {
+    setIsPasswordVisible(!isPasswordVisible)
+  }
 
   return (
     <div className="mt-8">
@@ -35,16 +43,25 @@ export default function LoginForm() {
           autoComplete="email"
           ref={emailRef}
         />
-        <Input
-          text="YOUR PASSWORD"
-          id="password"
-          name="password"
-          type="password"
-          fgColor="white"
-          bgColor="primary"
-          autoComplete="current-password"
-          ref={passwordRef}
-        />
+        <div>
+          <Input
+            text="YOUR PASSWORD"
+            id="password"
+            name="password"
+            type={isPasswordVisible ? "text" : "password"} 
+            fgColor="white"
+            bgColor="primary"
+            autoComplete="current-password"
+            right={
+              <FontAwesomeIcon
+                className="mx-2"
+                onClick={togglePasswordVisibility}
+                icon={isPasswordVisible ? faEyeSlash : faEye}
+              />
+            }
+            ref={passwordRef}
+          />
+        </div>
         <Text
           padding="6"
           text="Forgot your password?"

--- a/layout/Login/components/LoginForm/index.tsx
+++ b/layout/Login/components/LoginForm/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef } from "react";
 
 import { useAuth } from "@context/Auth";
 
@@ -7,15 +7,12 @@ import Text from "@layout/moonstone/authentication/Text";
 
 import Form from "@components/Form";
 import Input from "@components/Input";
-
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+import PasswordInput from "@components/PasswordInput";
 
 export default function LoginForm() {
   const { errors, login, isLoading } = useAuth();
   const emailRef = useRef(null);
   const passwordRef = useRef(null);
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   const onFinish = (event) => {
     event.preventDefault();
@@ -26,9 +23,6 @@ export default function LoginForm() {
     login({ email, password });
   };
 
-  const togglePasswordVisibility = () => {
-    setIsPasswordVisible(!isPasswordVisible);
-  };
 
   return (
     <div className="mt-8">
@@ -44,21 +38,10 @@ export default function LoginForm() {
           ref={emailRef}
         />
         <div>
-          <Input
+          <PasswordInput
             text="YOUR PASSWORD"
-            id="password"
-            name="password"
-            type={isPasswordVisible ? "text" : "password"}
             fgColor="white"
             bgColor="primary"
-            autoComplete="current-password"
-            right={
-              <FontAwesomeIcon
-                className="mx-2"
-                onClick={togglePasswordVisibility}
-                icon={isPasswordVisible ? faEyeSlash : faEye}
-              />
-            }
             ref={passwordRef}
           />
         </div>

--- a/layout/ResetPassword/components/ResetPasswordForm/index.tsx
+++ b/layout/ResetPassword/components/ResetPasswordForm/index.tsx
@@ -53,6 +53,7 @@ export default function ResetPasswordForm() {
         <Form onSubmit={onSubmit}>
           <PasswordInput
             text="PASSWORD"
+            id="password"
             name="password"
             type="password"
             fgColor="white"

--- a/layout/ResetPassword/components/ResetPasswordForm/index.tsx
+++ b/layout/ResetPassword/components/ResetPasswordForm/index.tsx
@@ -55,7 +55,6 @@ export default function ResetPasswordForm() {
             text="PASSWORD"
             id="password"
             name="password"
-            type="password"
             fgColor="white"
             bgColor="primary"
             ref={passwordRef}

--- a/layout/ResetPassword/components/ResetPasswordForm/index.tsx
+++ b/layout/ResetPassword/components/ResetPasswordForm/index.tsx
@@ -23,8 +23,9 @@ export default function ResetPasswordForm() {
   const passwordRef = useRef(null);
   const passwordConfirmationRef = useRef(null);
   const [errorMsg, updateErrorMsg] = useState(null);
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false)
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
+    useState(false);
 
   function onSubmit(event) {
     event.preventDefault();
@@ -53,12 +54,12 @@ export default function ResetPasswordForm() {
   }
 
   const togglePasswordVisibility = () => {
-    setIsPasswordVisible(!isPasswordVisible)
-  }
+    setIsPasswordVisible(!isPasswordVisible);
+  };
 
   const toggleConfirmPasswordVisibility = () => {
-    setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
-  }
+    setIsConfirmPasswordVisible(!isConfirmPasswordVisible);
+  };
 
   return (
     <>

--- a/layout/ResetPassword/components/ResetPasswordForm/index.tsx
+++ b/layout/ResetPassword/components/ResetPasswordForm/index.tsx
@@ -53,6 +53,8 @@ export default function ResetPasswordForm() {
         <Form onSubmit={onSubmit}>
           <PasswordInput
             text="PASSWORD"
+            name="password"
+            type="password"
             fgColor="white"
             bgColor="primary"
             ref={passwordRef}

--- a/layout/ResetPassword/components/ResetPasswordForm/index.tsx
+++ b/layout/ResetPassword/components/ResetPasswordForm/index.tsx
@@ -11,6 +11,9 @@ import ImageButton from "@components/ImageButton";
 import Form from "@components/Form";
 import Input from "@components/Input";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+
 export default function ResetPasswordForm() {
   const router = useRouter();
   const { token } = router.query;
@@ -20,6 +23,8 @@ export default function ResetPasswordForm() {
   const passwordRef = useRef(null);
   const passwordConfirmationRef = useRef(null);
   const [errorMsg, updateErrorMsg] = useState(null);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false)
 
   function onSubmit(event) {
     event.preventDefault();
@@ -47,6 +52,14 @@ export default function ResetPasswordForm() {
       });
   }
 
+  const togglePasswordVisibility = () => {
+    setIsPasswordVisible(!isPasswordVisible)
+  }
+
+  const toggleConfirmPasswordVisibility = () => {
+    setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
+  }
+
   return (
     <>
       {success === null && (
@@ -55,20 +68,34 @@ export default function ResetPasswordForm() {
             text="PASSWORD"
             id="password"
             name="password"
-            type="password"
+            type={isPasswordVisible ? "text" : "password"}
             autoComplete="current-password"
             fgColor="white"
             bgColor="primary"
+            right={
+              <FontAwesomeIcon
+                className="mx-2"
+                onClick={togglePasswordVisibility}
+                icon={isPasswordVisible ? faEyeSlash : faEye}
+              />
+            }
             ref={passwordRef}
           />
           <Input
             text="CONFIRM PASSWORD"
             id="confirm"
             name="confirm"
-            type="password"
+            type={isConfirmPasswordVisible ? "text" : "password"}
             autoComplete="current-password"
             fgColor="white"
             bgColor="primary"
+            right={
+              <FontAwesomeIcon
+                className="mx-2"
+                onClick={toggleConfirmPasswordVisibility}
+                icon={isConfirmPasswordVisible ? faEyeSlash : faEye}
+              />
+            }
             ref={passwordConfirmationRef}
           />
           <p className="mt-10 mb-10 text-center font-iregular text-failure">

--- a/layout/ResetPassword/components/ResetPasswordForm/index.tsx
+++ b/layout/ResetPassword/components/ResetPasswordForm/index.tsx
@@ -9,10 +9,7 @@ import Button from "@components/Button";
 import ImageButton from "@components/ImageButton";
 
 import Form from "@components/Form";
-import Input from "@components/Input";
-
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+import PasswordInput from "@components/PasswordInput";
 
 export default function ResetPasswordForm() {
   const router = useRouter();
@@ -23,9 +20,6 @@ export default function ResetPasswordForm() {
   const passwordRef = useRef(null);
   const passwordConfirmationRef = useRef(null);
   const [errorMsg, updateErrorMsg] = useState(null);
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
-    useState(false);
 
   function onSubmit(event) {
     event.preventDefault();
@@ -53,50 +47,22 @@ export default function ResetPasswordForm() {
       });
   }
 
-  const togglePasswordVisibility = () => {
-    setIsPasswordVisible(!isPasswordVisible);
-  };
-
-  const toggleConfirmPasswordVisibility = () => {
-    setIsConfirmPasswordVisible(!isConfirmPasswordVisible);
-  };
-
   return (
     <>
       {success === null && (
         <Form onSubmit={onSubmit}>
-          <Input
+          <PasswordInput
             text="PASSWORD"
-            id="password"
-            name="password"
-            type={isPasswordVisible ? "text" : "password"}
-            autoComplete="current-password"
             fgColor="white"
             bgColor="primary"
-            right={
-              <FontAwesomeIcon
-                className="mx-2"
-                onClick={togglePasswordVisibility}
-                icon={isPasswordVisible ? faEyeSlash : faEye}
-              />
-            }
             ref={passwordRef}
           />
-          <Input
+          <PasswordInput
             text="CONFIRM PASSWORD"
             id="confirm"
             name="confirm"
-            type={isConfirmPasswordVisible ? "text" : "password"}
-            autoComplete="current-password"
             fgColor="white"
             bgColor="primary"
-            right={
-              <FontAwesomeIcon
-                className="mx-2"
-                onClick={toggleConfirmPasswordVisibility}
-                icon={isConfirmPasswordVisible ? faEyeSlash : faEye}
-              />
-            }
             ref={passwordConfirmationRef}
           />
           <p className="mt-10 mb-10 text-center font-iregular text-failure">

--- a/layout/SignUp/components/SignUpForm/index.tsx
+++ b/layout/SignUp/components/SignUpForm/index.tsx
@@ -103,10 +103,11 @@ export default function SignUpForm() {
         />
         <PasswordInput
           text="CONFIRM PASSWORD"
+          id="confirm"
           name="confirm"
-          type="confirm"
           fgColor="white"
           bgColor="primary"
+          onChange={(e) => updatePasswordConfirmation(e.currentTarget.value)}
         />
         <Button
           text={scanning ? "STOP SCANNING" : "SCAN QR"}

--- a/layout/SignUp/components/SignUpForm/index.tsx
+++ b/layout/SignUp/components/SignUpForm/index.tsx
@@ -5,11 +5,9 @@ import { useAuth } from "@context/Auth";
 import Button from "@components/Button";
 import Form from "@components/Form";
 import Input from "@components/Input";
+import PasswordInput from "@components/PasswordInput";
 
 import BarebonesQRScanner from "@components/QRScanner/BarebonesQRScanner";
-
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
 export default function SignUpForm() {
   const { sign_up, isLoading, errors } = useAuth();
@@ -20,10 +18,6 @@ export default function SignUpForm() {
   const [password, updatePassword] = useState("");
   const [password_confirmation, updatePasswordConfirmation] = useState("");
   const [uuid, setUUID] = useState();
-
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
-    useState(false);
 
   const [local_error, updateError] = useState("");
   const [scanned, updateScanned] = useState(false);
@@ -70,14 +64,6 @@ export default function SignUpForm() {
     }
   };
 
-  const togglePasswordVisibility = () => {
-    setIsPasswordVisible(!isPasswordVisible);
-  };
-
-  const toggleConfirmPasswordVisibility = () => {
-    setIsConfirmPasswordVisible(!isConfirmPasswordVisible);
-  };
-
   return (
     <>
       <Form onSubmit={onFinish}>
@@ -107,39 +93,15 @@ export default function SignUpForm() {
           bgColor="primary"
           onChange={(e) => updateNickname(e.currentTarget.value)}
         />
-        <Input
+        <PasswordInput
           text="PASSWORD"
-          id="password"
-          name="password"
-          type={isPasswordVisible ? "text" : "password"}
-          autoComplete="current-password"
           fgColor="white"
           bgColor="primary"
-          onChange={(e) => updatePassword(e.currentTarget.value)}
-          right={
-            <FontAwesomeIcon
-              className="mx-2"
-              onClick={togglePasswordVisibility}
-              icon={isPasswordVisible ? faEyeSlash : faEye}
-            />
-          }
         />
-        <Input
+        <PasswordInput
           text="CONFIRM PASSWORD"
-          id="password"
-          name="password"
-          type={isConfirmPasswordVisible ? "text" : "password"}
-          autoComplete="current-password"
           fgColor="white"
           bgColor="primary"
-          onChange={(e) => updatePasswordConfirmation(e.currentTarget.value)}
-          right={
-            <FontAwesomeIcon
-              className="mx-2"
-              onClick={toggleConfirmPasswordVisibility}
-              icon={isConfirmPasswordVisible ? faEyeSlash : faEye}
-            />
-          }
         />
         <Button
           text={scanning ? "STOP SCANNING" : "SCAN QR"}

--- a/layout/SignUp/components/SignUpForm/index.tsx
+++ b/layout/SignUp/components/SignUpForm/index.tsx
@@ -95,12 +95,16 @@ export default function SignUpForm() {
         />
         <PasswordInput
           text="PASSWORD"
+          id="password"
+          name="password"
           fgColor="white"
           bgColor="primary"
           onChange={(e) => updatePassword(e.currentTarget.value)}
         />
         <PasswordInput
           text="CONFIRM PASSWORD"
+          name="confirm"
+          type="confirm"
           fgColor="white"
           bgColor="primary"
         />

--- a/layout/SignUp/components/SignUpForm/index.tsx
+++ b/layout/SignUp/components/SignUpForm/index.tsx
@@ -93,11 +93,7 @@ export default function SignUpForm() {
           bgColor="primary"
           onChange={(e) => updateNickname(e.currentTarget.value)}
         />
-        <PasswordInput
-          text="PASSWORD"
-          fgColor="white"
-          bgColor="primary"
-        />
+        <PasswordInput text="PASSWORD" fgColor="white" bgColor="primary" />
         <PasswordInput
           text="CONFIRM PASSWORD"
           fgColor="white"

--- a/layout/SignUp/components/SignUpForm/index.tsx
+++ b/layout/SignUp/components/SignUpForm/index.tsx
@@ -93,7 +93,12 @@ export default function SignUpForm() {
           bgColor="primary"
           onChange={(e) => updateNickname(e.currentTarget.value)}
         />
-        <PasswordInput text="PASSWORD" fgColor="white" bgColor="primary" />
+        <PasswordInput
+          text="PASSWORD"
+          fgColor="white"
+          bgColor="primary"
+          onChange={(e) => updatePassword(e.currentTarget.value)}
+        />
         <PasswordInput
           text="CONFIRM PASSWORD"
           fgColor="white"

--- a/layout/SignUp/components/SignUpForm/index.tsx
+++ b/layout/SignUp/components/SignUpForm/index.tsx
@@ -21,8 +21,9 @@ export default function SignUpForm() {
   const [password_confirmation, updatePasswordConfirmation] = useState("");
   const [uuid, setUUID] = useState();
 
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false)
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
+    useState(false);
 
   const [local_error, updateError] = useState("");
   const [scanned, updateScanned] = useState(false);
@@ -70,12 +71,12 @@ export default function SignUpForm() {
   };
 
   const togglePasswordVisibility = () => {
-    setIsPasswordVisible(!isPasswordVisible)
-  }
+    setIsPasswordVisible(!isPasswordVisible);
+  };
 
   const toggleConfirmPasswordVisibility = () => {
-    setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
-  }
+    setIsConfirmPasswordVisible(!isConfirmPasswordVisible);
+  };
 
   return (
     <>

--- a/layout/SignUp/components/SignUpForm/index.tsx
+++ b/layout/SignUp/components/SignUpForm/index.tsx
@@ -8,6 +8,9 @@ import Input from "@components/Input";
 
 import BarebonesQRScanner from "@components/QRScanner/BarebonesQRScanner";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+
 export default function SignUpForm() {
   const { sign_up, isLoading, errors } = useAuth();
 
@@ -17,6 +20,9 @@ export default function SignUpForm() {
   const [password, updatePassword] = useState("");
   const [password_confirmation, updatePasswordConfirmation] = useState("");
   const [uuid, setUUID] = useState();
+
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false)
 
   const [local_error, updateError] = useState("");
   const [scanned, updateScanned] = useState(false);
@@ -63,6 +69,14 @@ export default function SignUpForm() {
     }
   };
 
+  const togglePasswordVisibility = () => {
+    setIsPasswordVisible(!isPasswordVisible)
+  }
+
+  const toggleConfirmPasswordVisibility = () => {
+    setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
+  }
+
   return (
     <>
       <Form onSubmit={onFinish}>
@@ -96,21 +110,35 @@ export default function SignUpForm() {
           text="PASSWORD"
           id="password"
           name="password"
-          type="password"
+          type={isPasswordVisible ? "text" : "password"}
           autoComplete="current-password"
           fgColor="white"
           bgColor="primary"
           onChange={(e) => updatePassword(e.currentTarget.value)}
+          right={
+            <FontAwesomeIcon
+              className="mx-2"
+              onClick={togglePasswordVisibility}
+              icon={isPasswordVisible ? faEyeSlash : faEye}
+            />
+          }
         />
         <Input
           text="CONFIRM PASSWORD"
           id="password"
           name="password"
-          type="password"
+          type={isConfirmPasswordVisible ? "text" : "password"}
           autoComplete="current-password"
           fgColor="white"
           bgColor="primary"
           onChange={(e) => updatePasswordConfirmation(e.currentTarget.value)}
+          right={
+            <FontAwesomeIcon
+              className="mx-2"
+              onClick={toggleConfirmPasswordVisibility}
+              icon={isConfirmPasswordVisible ? faEyeSlash : faEye}
+            />
+          }
         />
         <Button
           text={scanning ? "STOP SCANNING" : "SCAN QR"}

--- a/pages/register/[uuid].js
+++ b/pages/register/[uuid].js
@@ -71,12 +71,16 @@ function Register() {
           />
           <PasswordInput
             text="PASSWORD"
+            name="password"
+            type="password"
             fgColor="white"
             bgColor="primary"
             onChange={(e) => updatePassword(e.currentTarget.value)}
           />
           <PasswordInput
             text="CONFIRM PASSWORD"
+            name="confirm"
+            type="confirm"
             fgColor="white"
             bgColor="primary"
             onChange={(e) => updatePasswordConfirmation(e.currentTarget.value)}

--- a/pages/register/[uuid].js
+++ b/pages/register/[uuid].js
@@ -69,11 +69,7 @@ function Register() {
             bgColor="primary"
             onChange={(e) => updateNickname(e.currentTarget.value)}
           />
-          <PasswordInput
-            text="PASSWORD"
-            fgColor="white"
-            bgColor="primary"
-          />
+          <PasswordInput text="PASSWORD" fgColor="white" bgColor="primary" />
           <PasswordInput
             text="CONFIRM PASSWORD"
             fgColor="white"

--- a/pages/register/[uuid].js
+++ b/pages/register/[uuid].js
@@ -71,16 +71,16 @@ function Register() {
           />
           <PasswordInput
             text="PASSWORD"
+            id="confirm"
             name="password"
-            type="password"
             fgColor="white"
             bgColor="primary"
             onChange={(e) => updatePassword(e.currentTarget.value)}
           />
           <PasswordInput
             text="CONFIRM PASSWORD"
+            id="confirm"
             name="confirm"
-            type="confirm"
             fgColor="white"
             bgColor="primary"
             onChange={(e) => updatePasswordConfirmation(e.currentTarget.value)}

--- a/pages/register/[uuid].js
+++ b/pages/register/[uuid].js
@@ -9,12 +9,10 @@ import Card from "@components/Card";
 import Return from "@components/Return";
 import Form from "@components/Form";
 import Input from "@components/Input";
+import PasswordInput from "@components/PasswordInput";
 
 import Title from "@layout/moonstone/authentication/Title";
 import Text from "@layout/moonstone/authentication/Text";
-
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
 function Register() {
   const { sign_up, errors, isLoading } = useAuth();
@@ -26,10 +24,6 @@ function Register() {
   const [nickname, updateNickname] = useState("");
   const [password, updatePassword] = useState("");
   const [password_confirmation, updatePasswordConfirmation] = useState("");
-
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
-    useState(false);
 
   const onFinish = (e) => {
     e.preventDefault();
@@ -75,39 +69,15 @@ function Register() {
             bgColor="primary"
             onChange={(e) => updateNickname(e.currentTarget.value)}
           />
-          <Input
+          <PasswordInput
             text="PASSWORD"
-            id="password"
-            name="password"
-            type={isPasswordVisible ? "text" : "password"}
-            autoComplete="current-password"
             fgColor="white"
             bgColor="primary"
-            onChange={(e) => updatePassword(e.currentTarget.value)}
-            right={
-              <FontAwesomeIcon
-                className="mx-2"
-                onClick={togglePasswordVisibility}
-                icon={isPasswordVisible ? faEyeSlash : faEye}
-              />
-            }
           />
-          <Input
+          <PasswordInput
             text="CONFIRM PASSWORD"
-            id="password"
-            name="password"
-            type={isConfirmPasswordVisible ? "text" : "password"}
-            autoComplete="current-password"
             fgColor="white"
             bgColor="primary"
-            onChange={(e) => updatePasswordConfirmation(e.currentTarget.value)}
-            right={
-              <FontAwesomeIcon
-                className="mx-2"
-                onClick={toggleConfirmPasswordVisibility}
-                icon={isConfirmPasswordVisible ? faEyeSlash : faEye}
-              />
-            }
           />
           <Button
             type="submit"

--- a/pages/register/[uuid].js
+++ b/pages/register/[uuid].js
@@ -69,11 +69,17 @@ function Register() {
             bgColor="primary"
             onChange={(e) => updateNickname(e.currentTarget.value)}
           />
-          <PasswordInput text="PASSWORD" fgColor="white" bgColor="primary" />
+          <PasswordInput
+            text="PASSWORD"
+            fgColor="white"
+            bgColor="primary"
+            onChange={(e) => updatePassword(e.currentTarget.value)}
+          />
           <PasswordInput
             text="CONFIRM PASSWORD"
             fgColor="white"
             bgColor="primary"
+            onChange={(e) => updatePasswordConfirmation(e.currentTarget.value)}
           />
           <Button
             type="submit"

--- a/pages/register/[uuid].js
+++ b/pages/register/[uuid].js
@@ -27,9 +27,9 @@ function Register() {
   const [password, updatePassword] = useState("");
   const [password_confirmation, updatePasswordConfirmation] = useState("");
 
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false)
-
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
+    useState(false);
 
   const onFinish = (e) => {
     e.preventDefault();

--- a/pages/register/[uuid].js
+++ b/pages/register/[uuid].js
@@ -13,6 +13,9 @@ import Input from "@components/Input";
 import Title from "@layout/moonstone/authentication/Title";
 import Text from "@layout/moonstone/authentication/Text";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+
 function Register() {
   const { sign_up, errors, isLoading } = useAuth();
   const router = useRouter();
@@ -23,6 +26,10 @@ function Register() {
   const [nickname, updateNickname] = useState("");
   const [password, updatePassword] = useState("");
   const [password_confirmation, updatePasswordConfirmation] = useState("");
+
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false)
+
 
   const onFinish = (e) => {
     e.preventDefault();
@@ -72,21 +79,35 @@ function Register() {
             text="PASSWORD"
             id="password"
             name="password"
-            type="password"
+            type={isPasswordVisible ? "text" : "password"}
             autoComplete="current-password"
             fgColor="white"
             bgColor="primary"
             onChange={(e) => updatePassword(e.currentTarget.value)}
+            right={
+              <FontAwesomeIcon
+                className="mx-2"
+                onClick={togglePasswordVisibility}
+                icon={isPasswordVisible ? faEyeSlash : faEye}
+              />
+            }
           />
           <Input
             text="CONFIRM PASSWORD"
             id="password"
             name="password"
-            type="password"
+            type={isConfirmPasswordVisible ? "text" : "password"}
             autoComplete="current-password"
             fgColor="white"
             bgColor="primary"
             onChange={(e) => updatePasswordConfirmation(e.currentTarget.value)}
+            right={
+              <FontAwesomeIcon
+                className="mx-2"
+                onClick={toggleConfirmPasswordVisibility}
+                icon={isConfirmPasswordVisible ? faEyeSlash : faEye}
+              />
+            }
           />
           <Button
             type="submit"


### PR DESCRIPTION
Added see Password Button at all login/signup forms.

I didn't checked the changes at `pages/register/[uuid].js` (<strike>I'm wating for feedback  in how access this page</strike> seems to be unused and maybe will be deleted).

I also needed edit Input Component to accept a `right children` component.

Issue related: https://github.com/cesium/seium.org/issues/527

![image](https://github.com/cesium/seium.org/assets/49988070/d65608f3-5ad9-49a0-9f12-26e01c9c7a4a)
