### PR TITLE
refactor: align landing footer

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -116,13 +116,13 @@ export default function Footer(props: IFooterProps) {
         </div>
 
         <div className="flex-2">
-          <div className="grid grid-rows-2 justify-items-center gap-8 font-iregular text-sm text-white whitespace-nowrap lg:grid-cols-2 lg:justify-items-start">
+          <div className="grid grid-rows-2 justify-items-center gap-8 whitespace-nowrap font-iregular text-sm text-white lg:grid-cols-2 lg:justify-items-start">
             <Link
               href="https://2022.seium.org/"
               className="text-white hover:underline"
             >
               Previous Edition
-            </Link> 
+            </Link>
             <Link
               href="https://docs.google.com/forms/d/e/1FAIpQLSdV1bSyW2tcLuTC_jJCGdZ5NZHUlgETK7nQkOmyDzwb7eFS4Q/viewform"
               className="hover:underline"

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -85,9 +85,8 @@ export default function Footer(props: IFooterProps) {
       className={`spacing ${styles.bgTransition} bg-secondary`}
       ref={observe}
     >
-      <div className="flex flex-col lg:flex-row justify-between gap-16 py-10">
-
-        <div className="flex justify-center items-start font-ibold lg:justify-start">
+      <div className="flex flex-col justify-between gap-16 py-10 lg:flex-row">
+        <div className="flex items-start justify-center font-ibold lg:justify-start">
           <Image
             src="/images/sei-logo.svg"
             width={100}
@@ -102,7 +101,7 @@ export default function Footer(props: IFooterProps) {
           </p>
         </div>
 
-        <div className="hidden lg:flex mt-20 mx-2 justify-center pb-10">
+        <div className="mx-2 mt-20 hidden justify-center pb-10 lg:flex">
           <Animation
             text={
               props.footerAnimationText != undefined ? (

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -116,16 +116,13 @@ export default function Footer(props: IFooterProps) {
         </div>
 
         <div className="flex-2">
-          <div className="grid grid-rows-2 justify-items-center gap-8 font-iregular text-sm text-white lg:grid-cols-2 lg:justify-items-end">
+          <div className="grid grid-rows-2 justify-items-center gap-8 font-iregular text-sm text-white whitespace-nowrap lg:grid-cols-2 lg:justify-items-start">
             <Link
               href="https://2022.seium.org/"
               className="text-white hover:underline"
             >
               Previous Edition
-            </Link>
-            <Link href="/docs/regulamento.pdf" className="hover:underline">
-              General Regulation
-            </Link>
+            </Link> 
             <Link
               href="https://docs.google.com/forms/d/e/1FAIpQLSdV1bSyW2tcLuTC_jJCGdZ5NZHUlgETK7nQkOmyDzwb7eFS4Q/viewform"
               className="hover:underline"
@@ -134,6 +131,9 @@ export default function Footer(props: IFooterProps) {
             </Link>
             <Link href="/docs/survival.pdf" className="hover:underline">
               Survival Guide
+            </Link>
+            <Link href="/docs/regulamento.pdf" className="hover:underline">
+              General Regulation
             </Link>
           </div>
           <div className="flex justify-center lg:justify-end">

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -85,24 +85,38 @@ export default function Footer(props: IFooterProps) {
       className={`spacing ${styles.bgTransition} bg-secondary`}
       ref={observe}
     >
-      <div className="justify-center lg:flex">
-        <div className="py- flex-1">
-          <div className="flex justify-center font-ibold lg:justify-start">
-            <Image
-              src="/images/sei-logo.svg"
-              width={100}
-              height={100}
-              alt="SEI Logo"
-            />
-            <p className="pl-6 text-white lg:flex-1">
-              Semana da <br />
-              Engenharia
-              <br />
-              Informática
-            </p>
-          </div>
+      <div className="flex flex-col lg:flex-row justify-between gap-16 py-10">
+
+        <div className="flex justify-center items-start font-ibold lg:justify-start">
+          <Image
+            src="/images/sei-logo.svg"
+            width={100}
+            height={100}
+            alt="SEI Logo"
+          />
+          <p className="pl-6 text-white lg:flex-1">
+            Semana da <br />
+            Engenharia
+            <br />
+            Informática
+          </p>
         </div>
-        <div className="flex-2 py-10">
+
+        <div className="hidden lg:flex mt-20 mx-2 justify-center pb-10">
+          <Animation
+            text={
+              props.footerAnimationText != undefined ? (
+                props.footerAnimationText
+              ) : (
+                <DefaultAnimation />
+              )
+            }
+          >
+            {props.children}
+          </Animation>
+        </div>
+
+        <div className="flex-2">
           <div className="grid grid-rows-2 justify-items-center gap-8 font-iregular text-sm text-white lg:grid-cols-2 lg:justify-items-end">
             <Link
               href="https://2022.seium.org/"
@@ -129,19 +143,6 @@ export default function Footer(props: IFooterProps) {
             </div>
           </div>
         </div>
-      </div>
-      <div className="invisible -mt-20 flex justify-center pb-10 lg:visible">
-        <Animation
-          text={
-            props.footerAnimationText != undefined ? (
-              props.footerAnimationText
-            ) : (
-              <DefaultAnimation />
-            )
-          }
-        >
-          {props.children}
-        </Animation>
       </div>
     </div>
   );


### PR DESCRIPTION
Landing Footer Fixed. Please just note that the right texts of the footer have different behavior about the wrap, that as far as I know, isn't so easy to fix it with just css. Although there isn't any text overflow and the align is fixed.

https://github.com/cesium/seium.org/assets/49988070/2a95004b-4959-4eb5-8966-0e9f64e4472c


Issue: https://github.com/cesium/seium.org/issues/500