### PR TITLE
feat: fetch event dates from schedule

### DIFF
--- a/components/Schedule/index.jsx
+++ b/components/Schedule/index.jsx
@@ -4,6 +4,8 @@ import Day from "./Day";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 
+import scheduleData from "/data/schedule.json";
+
 function leapYear(year) {
   return (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
 }
@@ -87,8 +89,11 @@ function addDate(date, days) {
 }
 
 export default function Schedule(props) {
-  const min_date = "2023/2/14";
-  const max_date = "2023/2/17";
+  /* Fetch first and last day of the event from schedule data */
+  const eventDates = scheduleData.map((day) => day.date).sort();
+  const min_date = eventDates[0];
+  const max_date = eventDates[eventDates.length - 1];
+
   const defaultFilter = props.filters === undefined ? "" : props.filters;
 
   //calculate default date

--- a/layout/Home/components/Hero/Title/index.tsx
+++ b/layout/Home/components/Hero/Title/index.tsx
@@ -1,10 +1,27 @@
 import TypeWriter from "typewriter-effect";
+import schedule from "@data/schedule.json";
 
 export default function Title() {
+  /* Parse event dates info from schedule data */
+  const dates = schedule.map((day) => day.date).sort();
+  const firstDayData = dates[0].split("/");
+
+  /* Parse year */
+  const year = firstDayData[0];
+
+  /* Parse month */
+  const month = new Intl.DateTimeFormat("en-US", { month: "long" }).format(
+    new Date().setMonth(parseInt(firstDayData[1]) - 1)
+  );
+
+  /* Parse first and last day of the event */
+  const firstDay = firstDayData.pop();
+  const lastDay = dates.pop().split("/").pop();
+
   return (
     <div className="relative z-20 font-bold">
       <h5 className="font-terminal-uppercase m-1 text-2xl text-quinary">
-        14-17 February 2023
+        {firstDay}-{lastDay} {month} {year}
       </h5>
       {/* 2xl:leading-[6.5rem] is intended to only work with the following font - Terminal */}
       <h1


### PR DESCRIPTION
Fix #514, didn't implement exactly what the issue describes, since, in my opinion, it makes way more sense to fetch them from the already available schedule data. (enforcing that the event start date and end date match the schedule)