### PR TITLE
fix: wheel button

### DIFF
--- a/layout/Attendee/Wheel/Wheel.tsx
+++ b/layout/Attendee/Wheel/Wheel.tsx
@@ -202,18 +202,20 @@ function WheelPage() {
             <div className="m-auto h-72 w-72 xs:h-80 xs:w-80 sm:h-96 sm:w-96">
               <WheelComponent steps={16} angle={st.angle} />
             </div>
-            <Button
-              className={`${
-                canSpin()
-                  ? "cursor-pointer bg-quinary"
-                  : "bg-gray-400 opacity-50"
-              } mt-10 block h-20 w-64`}
-              disabled={!canSpin()}
-              onClick={spinTheWheel}
-              title="SPIN THE WHEEL"
-              description={`${price} tokens💰`}
-              bold={true}
-            />
+            {price != null && (
+              <Button
+                className={`${
+                  canSpin()
+                    ? "cursor-pointer bg-quinary"
+                    : "bg-gray-400 opacity-50"
+                } mt-10 block h-20 w-64`}
+                disabled={!canSpin()}
+                onClick={spinTheWheel}
+                title="SPIN THE WHEEL"
+                description={`${price} tokens💰`}
+                bold={true}
+              />
+            )}
           </div>
         </div>
         <div className="col-span-1 float-right w-full 2xl:w-1/2 2xl:pl-6">

--- a/layout/Attendee/Wheel/components/WheelComponent/index.tsx
+++ b/layout/Attendee/Wheel/components/WheelComponent/index.tsx
@@ -11,7 +11,7 @@ export default function Wheel({ steps, angle }) {
     colors.push((255.0 * i) / (steps - 1));
   }
 
-  colors = colors.map((entry) => "#F52AB1" + toHex(entry));
+  colors = colors.map((entry) => "#FF800D" + toHex(entry));
 
   const styleGlobal = {
     background: "conic-gradient(" + colors.join(",") + ")",


### PR DESCRIPTION
Fetching the wheel spin price takes some time, while the page waited for that fetch call the button would display the price as `null`. Now, while the price hasn't loaded yet the button isn't shown.