### PR TITLE
feat: smooth out transitions and styling

### DIFF
--- a/components/Schedule/Table/Block/style.module.css
+++ b/components/Schedule/Table/Block/style.module.css
@@ -21,7 +21,8 @@
 }
 
 .clickable:hover .gridBlock {
-  @apply border-quinary bg-quinary;
+  @apply bg-white/10;
+  @apply transition-colors;
 }
 
 .clickable .gridBlock a {
@@ -49,6 +50,10 @@
 
 .author:hover {
   text-decoration: underline;
+}
+
+.clickable:hover .author {
+  @apply text-white;
 }
 
 .description {
@@ -97,11 +102,11 @@
 }
 
 .expand {
-  @apply items-center rounded-full border border-white text-center font-ibold text-3xl text-white shadow-sm;
+  @apply items-center rounded-full border border-white text-center font-ibold text-3xl text-white shadow-sm hover:bg-white/20;
   display: inline-block;
   width: 5rem;
 }
 
 .clickable:hover .expand {
-  @apply border-primary text-primary;
+  @apply border-white bg-quinary text-white;
 }

--- a/components/Speaker/index.jsx
+++ b/components/Speaker/index.jsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function Speaker({ id, name, job, company }) {
   return (
-    <div className="z-30 text-white grayscale filter hover:text-quinary hover:filter-none">
+    <div className="z-30 text-white grayscale filter transition-all hover:text-quinary hover:filter-none">
       <Image
         src={`/images/speakers/${id}.png`}
         width="210"

--- a/layout/Home/components/Hero/Pitch/index.jsx
+++ b/layout/Home/components/Hero/Pitch/index.jsx
@@ -11,7 +11,7 @@ export default function Pitch() {
         <a href="/team">
           <Button
             title="MEET THE TEAM"
-            className="h-20 w-56 border-2 border-white text-white hover:border-quinary hover:text-quinary"
+            className="h-20 w-56 border-2 border-white text-white transition-colors hover:border-quinary hover:bg-quinary/10 hover:text-quinary"
             bold={true}
           />
         </a>

--- a/layout/Home/components/Partners/index.jsx
+++ b/layout/Home/components/Partners/index.jsx
@@ -11,7 +11,7 @@ export default function Partners() {
       <div className="my-10 flex flex-wrap items-center justify-center gap-10">
         {partners.map((partner, i) => (
           <div
-            className="m-auto w-40 select-none grayscale filter hover:filter-none"
+            className="m-auto w-40 select-none grayscale filter transition-all hover:filter-none"
             key={i}
           >
             <a href={partner.url} target="_blank" rel="noreferrer">

--- a/layout/Home/components/Speakers/index.jsx
+++ b/layout/Home/components/Speakers/index.jsx
@@ -16,7 +16,7 @@ export default function Speakers() {
           <Link href="/speakers">
             <Button
               title="MEET THE SPEAKERS"
-              className="h-20 w-full select-none border-2 border-white text-white hover:border-quinary hover:text-quinary"
+              className="h-20 w-full select-none border-2 border-white text-white transition-colors hover:border-quinary hover:bg-quinary/10 hover:text-quinary"
               bold={true}
             />
           </Link>

--- a/layout/Home/components/Sponsors/index.jsx
+++ b/layout/Home/components/Sponsors/index.jsx
@@ -6,13 +6,14 @@ import sponsors from "/data/sponsors.json";
 
 function Tab({ tabName, selected, onSelect }) {
   const classes1 =
-    "text-center w-60 font-imedium text-white text-lg md:text-2xl pt-3 cursor-pointer";
-  const classes2 = "w-full pt-4 border-solid border-b-[10px]";
+    "text-center w-60 font-medium text-white text-lg md:text-2xl pt-3 cursor-pointer transition-colors pb-4 border-b-[10px] border-white/10 hover:border-white/30 border-solid";
 
   return (
-    <div className={classes1} onClick={onSelect}>
+    <div
+      className={classes1 + (selected && ` border-white/100`)}
+      onClick={onSelect}
+    >
       {tabName}
-      <div className={selected ? classes2 : `opacity-20 ${classes2}`} />
     </div>
   );
 }


### PR DESCRIPTION
Polished some edges that were itching me in a bad way.

## Changes

| Before | After |
| --- | --- |
| ![Screenshot_20240114_221447](https://github.com/cesium/seium.org/assets/80540164/5947e090-ebfd-4019-92ab-6bc8d5efb211) Terrible contrast when hovering, specially in speaker name. No transition between colors. | ![Screenshot_20240114_221454](https://github.com/cesium/seium.org/assets/80540164/a8b59334-738f-4f87-b0ae-81b0170c0c1a) Better contrast and easier on the eyes, maintains bright eye-catching orange on the "+" button instead. |
| ![Screenshot_20240114_221659](https://github.com/cesium/seium.org/assets/80540164/56cc49a8-d041-466e-8517-5e34f6977736) No hover feedback.| ![Screenshot_20240114_221705](https://github.com/cesium/seium.org/assets/80540164/5bf049a9-a996-44fc-ba1c-9402295f6ed9)  Feedback on hover by smoothly changing background color. |
| ![Screenshot_20240114_221900](https://github.com/cesium/seium.org/assets/80540164/0aec6080-13ab-4843-b28b-b1b40804fb41) The orange color when hovering makes the button appear darker and less highlighted. | ![Screenshot_20240114_221905](https://github.com/cesium/seium.org/assets/80540164/6f2fd456-547f-4b4b-b69b-72b1b6db6610)  Light orange background helps to better highlight the button when hovered. |

### Sponsor Navigation

**Before:**

No difference between states / no transition.

| Normal | Hover |
| --- | --- |
| ![Screenshot_20240114_222327](https://github.com/cesium/seium.org/assets/80540164/8c26bdb1-785d-40a0-91e0-64991162ee52) | ![Screenshot_20240114_222331](https://github.com/cesium/seium.org/assets/80540164/2a8df90a-8797-4483-a1ab-e0686bce6eb6)

**After:**

Increased opacity when hovering and smooth transition between states + fixed css typo in `font-medium`.

| Normal | Hover |
| --- | --- |
| ![Screenshot_20240114_222336](https://github.com/cesium/seium.org/assets/80540164/10aa11c4-3f91-47d0-b7b1-d4dd9cc047b2) | ![Screenshot_20240114_222342](https://github.com/cesium/seium.org/assets/80540164/a807f392-ca8b-43e4-aea0-03c27a24928b) |

### Speakers

Smooth transition between gray scale and color.

![image](https://github.com/cesium/seium.org/assets/80540164/e7f9ad97-c32c-4170-83d9-87d829ccbc4b)

### Partners

Smooth transition between gray scale and color.

![image](https://github.com/cesium/seium.org/assets/80540164/bc8ebac7-d2ae-4238-af01-9462c9b5f62b)

