### PR TITLE
fix(block-item): add hover color through group hover on speaker name

### DIFF
--- a/components/Schedule/Table/Block/index.jsx
+++ b/components/Schedule/Table/Block/index.jsx
@@ -42,7 +42,7 @@ function BlockItem({
       </p>
 
       <ul
-        className={`${styles.authors} flex font-iregular text-sm text-gray-400`}
+        className={`${styles.authors} flex font-iregular text-sm text-gray-400 group-hover:text-primary`}
       >
         {author && (
           <li className={styles.listElem}>
@@ -109,7 +109,7 @@ function BlockItem({
   );
 
   return (
-    <div className={skipLink ? "" : styles.clickable}>
+    <div className={`group ${skipLink ? "" : styles.clickable}`}>
       {!skipLink && (
         <Link href={`schedule/#${id}`} className="absolute h-full w-full" />
       )}


### PR DESCRIPTION
It was unreadable, I think it looks much nicer now:

Before:

![ArcoLinux_2024-01-15_08-08-46](https://github.com/cesium/seium.org/assets/55213469/297f796a-9746-4460-a207-32f6a898cacb)


After:

![ArcoLinux_2024-01-15_08-08-12](https://github.com/cesium/seium.org/assets/55213469/644fdae6-af73-4886-8200-f01a2f023d47)
